### PR TITLE
Remove CORS middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/boltdb/bolt"
 	oidc "github.com/coreos/go-oidc"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/tevino/abool"
@@ -66,7 +65,7 @@ func main() {
 	log.Infof("Starting server at %v:%v", c.Hostname, c.Port)
 	stopCh := make(chan struct{})
 	go func(stopCh chan struct{}) {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", c.Hostname, c.Port), handlers.CORS()(router)))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", c.Hostname, c.Port), router))
 		close(stopCh)
 	}(stopCh)
 

--- a/web_server.go
+++ b/web_server.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 	"html/template"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -83,7 +83,7 @@ func (s *WebServer) Start(addr string) error {
 			),
 		)
 
-	return http.ListenAndServe(addr, handlers.CORS()(router))
+	return http.ListenAndServe(addr, router)
 }
 
 // siteHandler returns an http.HandlerFunc that serves a given template


### PR DESCRIPTION
The AuthService used a CORS middleware as a remnant of the original
fork:
ajmyyra/ambassador-auth-oidc@43dd5ae

The CORS middleware permits requests with certain default methods and
headers. However, since the default answer is 200, what it actually does
is proxy the CORS requests for those methods. I don't like the fact that we
don't set the response code explicitly. We should either remove this middleware
or document its use clearly.

Cherry-pick from: https://github.com/arrikto/oidc-authservice/pull/58

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Requirements:**
- Make sure your PR conforms to our [contribution guidelines](../CONTRIBUTING.md)
