### PR TITLE
idtoken: Add support for device auth

### DIFF
--- a/authenticator/idtoken.go
+++ b/authenticator/idtoken.go
@@ -32,6 +32,8 @@ func NewIdTokenAuthenticator(
 func (s *idTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Request) (*User, error) {
 	logger := logger.ForRequest(r)
 
+	clientID := r.Header.Get("X-OIDC-Client-Id")
+
 	// get id-token from header
 	bearer := oidc.GetBearerToken(r.Header.Get(s.header))
 	if len(bearer) == 0 {
@@ -41,7 +43,7 @@ func (s *idTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Reque
 	ctx := s.tlsCfg.Context(r.Context())
 
 	// Verifying received ID token
-	token, err := s.sessionManager.Verify(ctx, bearer)
+	token, err := s.sessionManager.Verify(ctx, bearer, clientID)
 	if err != nil {
 		logger.Errorf("id-token verification failed: %v", err)
 		return nil, nil

--- a/server.go
+++ b/server.go
@@ -175,7 +175,7 @@ func (s *server) authCodeFlowAuthenticationRequest(w http.ResponseWriter, r *htt
 		returnMessage(w, http.StatusInternalServerError, "Failed to save state in store.")
 		return
 	}
-
+	w.Header().Add("X-OIDC-Device-Flow-Url", s.sessionManager.DeviceAuthURL())
 	http.Redirect(w, r, s.sessionManager.AuthCodeURL(c.Value), http.StatusFound)
 }
 
@@ -231,7 +231,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verifying received ID token
-	_, err = s.sessionManager.Verify(ctx, rawIDToken)
+	_, err = s.sessionManager.Verify(ctx, rawIDToken, "")
 	if err != nil {
 		logger.Errorf("Not able to verify ID token: %v", err)
 		returnMessage(w, http.StatusInternalServerError, "Unable to verify ID token.")


### PR DESCRIPTION
In order to support device authorization we need to be able to use a
client id that is associated with the device in question. We also need
to assist the client in ultimately locating the correct authorization
endpoint.

This change does the following:

- adds a header, X-OIDC-Device-Flow-Url, with the device authorization
  URL to the redirect.  Currently this appends '/device/code' to the
  provider URL, because the support isn't present in the upstream
  libraries and injects it into the header

- accepts a header, X-OIDC-Client-Id, as an alternative to the
  oidc-authservice client id so that devices can use their own client
  id and client secret