### PR TITLE
Allow empty user id claim

### DIFF
--- a/authenticator/idtoken.go
+++ b/authenticator/idtoken.go
@@ -58,7 +58,9 @@ func (s *idTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Reque
 
 	userID, err := claims.UserID()
 	if err != nil {
-		// No USERID_CLAIM, pass this authenticator
+		// this token doesn't have a userid claim (or the associated groups)
+		// we return an empty user here because this is expected in the case
+		// of client credentials flows
 		logger.Info("USERID_CLAIM doesn't exist in the id token")
 		return &User{}, nil
 	}

--- a/authenticator/idtoken.go
+++ b/authenticator/idtoken.go
@@ -59,8 +59,8 @@ func (s *idTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Reque
 	userID, err := claims.UserID()
 	if err != nil {
 		// No USERID_CLAIM, pass this authenticator
-		logger.Error("USERID_CLAIM doesn't exist in the id token")
-		return nil, nil
+		logger.Info("USERID_CLAIM doesn't exist in the id token")
+		return &User{}, nil
 	}
 
 	user := User{Name: userID, Groups: claims.Groups()}


### PR DESCRIPTION
For client credentials flow the user id claim will be empty because
only the client's credentials are used to authenticate.  In this case,
we return an empty User object to indicate that the credentials are
valid but there is no associated user.

