### PR TITLE
authorizer: add default option to config matcher

### DIFF
--- a/authorizer/config_test.go
+++ b/authorizer/config_test.go
@@ -1,7 +1,11 @@
 package authorizer
 
 import (
+	"net/http"
 	"testing"
+
+	"github.com/arrikto/oidc-authservice/authenticator"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -21,13 +25,78 @@ func TestLoadConfig(t *testing.T) {
 		t.Errorf("error parsing config: %v", err)
 	}
 	t.Logf("loaded config: %v", *authzConfig)
-
 }
 
-func TestConfigAuthorizer(t *testing.T) {
-	ca, err := NewConfigAuthorizer("./testdata/authz.yaml")
-	if err != nil {
-		t.Fatal(err)
+func user(n string, groups ...string) *authenticator.User {
+	return &authenticator.User{Name: n, Groups: groups}
+}
+
+func TestConfigAuthorizerMatching(t *testing.T) {
+	type matchTCase struct {
+		host  string
+		match bool
+		user  *authenticator.User
 	}
-	t.Logf("created ca %+v", ca)
+
+	tests := []struct {
+		in       string
+		behavior []matchTCase
+	}{
+		{
+			in: "./testdata/authz.yaml",
+			behavior: []matchTCase{
+				// foo.bar.io tests
+				{"foo.bar.io", false, user("none")},
+				{"foo.bar.io", false, user("wrong", "wrong")},
+				{"foo.bar.io", false, user("match1", "a@b.go")},
+				{"foo.bar.io", false, user("match2", "ok@ok.go", "b@b.go")},
+				// bar.io tests
+				{"foo.bar.io", false, user("matching foo", "a@b.go")},
+				{"foo.bar.io", false, user("match", "c@c.go")},
+				// default unknown host behavior
+				{"unknown host", true, user("no groups")},
+			},
+		},
+		{
+			in: "./testdata/allowAll.yaml",
+			behavior: []matchTCase{
+				{"happytohaveyou.io", true, user("no groups")},
+				{"nothappy.io", false, user("no groups")},
+				{"unknown host", true, user("no groups")},
+			},
+		},
+		{
+			in: "./testdata/allowNoneDefault.yaml",
+			behavior: []matchTCase{
+				{"unknown host", false, user("no groups")},
+				{"nothappy.io", false, user("no groups")},
+				{"ok.io", true, user("matches", "foo@bar.go")},
+			},
+		},
+		{
+			in: "./testdata/allowSingleGroupDefault.yaml",
+			behavior: []matchTCase{
+				{"unknown host", false, user("no groups")},
+				{"unknown host", true, user("default match", "foo")},
+				// doesn't match other matcher
+				{"foo.bar.io", false, user("default doesnt match", "foo")},
+				{"foo.bar.io", false, user("match", "baz@bar.go")},
+			},
+		},
+	}
+
+	for _, tcase := range tests {
+		t.Run(tcase.in, func(t *testing.T) {
+			ca, err := NewConfigAuthorizer(tcase.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// t.Logf("created ca %+v", ca)
+			for _, tc := range tcase.behavior {
+				authed, reason, err := ca.Authorize(&http.Request{Host: tc.host}, tc.user)
+				require.NoError(t, err, "unexpected error")
+				require.Equalf(t, tc.match, authed, "%s", reason)
+			}
+		})
+	}
 }

--- a/authorizer/core.go
+++ b/authorizer/core.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arrikto/oidc-authservice/authenticator"
@@ -11,4 +12,41 @@ import (
 // https://github.com/kubernetes/apiserver/blob/master/pkg/authorization/authorizer/interfaces.go#L67-L72
 type Authorizer interface {
 	Authorize(r *http.Request, user *authenticator.User) (allowed bool, reason string, err error)
+}
+
+const (
+	wildcardMatcher = "*"
+)
+
+// ruleMatcher is a struct which is used to define matching access based on group
+// membership.
+type ruleMatcher struct {
+	from     string
+	allowAny map[string]struct{}
+}
+
+func newRuleMatcher(allowlist []string) ruleMatcher {
+	m := map[string]struct{}{}
+	for _, g := range allowlist {
+		m[g] = struct{}{}
+	}
+	return ruleMatcher{
+		from:     fmt.Sprintf("%v", allowlist),
+		allowAny: m,
+	}
+}
+
+// Match matches a user to a set of rules.
+//
+// It also returns a reason for why the user was allowed access.
+func (rm ruleMatcher) Match(user *authenticator.User) (bool, string) {
+	if _, ok := rm.allowAny[wildcardMatcher]; ok {
+		return ok, "wildcard matching"
+	}
+	for _, g := range user.Groups {
+		if _, ok := rm.allowAny[g]; ok {
+			return ok, fmt.Sprintf("in group %s", g)
+		}
+	}
+	return false, fmt.Sprintf("requires membership in one of %v", rm.from)
 }

--- a/authorizer/groups.go
+++ b/authorizer/groups.go
@@ -1,45 +1,22 @@
 package authorizer
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/arrikto/oidc-authservice/authenticator"
 )
 
-const (
-	wildcardMatcher = "*"
-)
-
 type groupsAuthorizer struct {
-	allowed map[string]bool
+	m ruleMatcher
 }
 
 func NewGroupsAuthorizer(allowlist []string) Authorizer {
-	allowed := map[string]bool{}
-	for _, g := range allowlist {
-		if g == wildcardMatcher {
-			allowed = map[string]bool{g: true}
-			break
-		}
-		allowed[g] = true
-	}
 	return &groupsAuthorizer{
-		allowed: allowed,
+		m: newRuleMatcher(allowlist),
 	}
 }
 
 func (ga *groupsAuthorizer) Authorize(r *http.Request, user *authenticator.User) (bool, string, error) {
-	if ga.allowed[wildcardMatcher] {
-		return true, "", nil
-	}
-	for _, g := range user.Groups {
-		if ga.allowed[g] {
-			return true, "", nil
-		}
-	}
-	reason := fmt.Sprintf("User's groups ([%s]) are not in allowlist.",
-		strings.Join(user.Groups, ","))
-	return false, reason, nil
+	authed, reason := ga.m.Match(user)
+	return authed, reason, nil
 }

--- a/authorizer/groups_test.go
+++ b/authorizer/groups_test.go
@@ -42,13 +42,13 @@ func TestGroupsAuthorizer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			authz := newGroupsAuthorizer(test.allowlist)
+			authz := NewGroupsAuthorizer(test.allowlist)
 			user := &authenticator.User{
 				Groups: test.userGroups,
 			}
 			allowed, reason, err := authz.Authorize(nil, user)
-			require.NoError(t, err, "Unexpected error")
-			require.Equalf(t, test.allowed, allowed, "Reason: %s", reason)
+			require.NoError(t, err, "unexpected error")
+			require.Equalf(t, test.allowed, allowed, "%s", reason)
 		})
 	}
 }

--- a/authorizer/testdata/allowAll.yaml
+++ b/authorizer/testdata/allowAll.yaml
@@ -1,0 +1,6 @@
+rules:
+  happytohaveyou.io:
+    groups:
+      - '*'
+  nothappy.io:
+    groups:

--- a/authorizer/testdata/allowNoneDefault.yaml
+++ b/authorizer/testdata/allowNoneDefault.yaml
@@ -1,0 +1,6 @@
+default:
+  groups:
+rules:
+  ok.io:
+    groups:
+      - foo@bar.go

--- a/authorizer/testdata/allowSingleGroupDefault.yaml
+++ b/authorizer/testdata/allowSingleGroupDefault.yaml
@@ -1,0 +1,8 @@
+default:
+  groups:
+    - foo
+rules:
+  foo.bar.io:
+    groups:
+      - baz@bar.com
+      - beef@bar.com

--- a/authorizer/testdata/authz.yaml
+++ b/authorizer/testdata/authz.yaml
@@ -1,0 +1,8 @@
+rules:
+  foo.bar.io:
+    groups:
+      - a@b.com
+      - b@b.com
+  bar.io:
+    groups:
+      - c@c.com


### PR DESCRIPTION
This lets you define a default config to deny access from any non matching hosts.

```yaml
default: 
  groups:
rules:
```

The default behaviour matches the old behaviour, and is equivalent to:

```yaml
default: 
  groups:
    - '*'
rules:
```

To support that change, I refactored both authorizers to use the same underlying matcher. This means we now support wildcard matches for hosts as we do there:

```yaml
rules:
  example.com:
    groups:
      - '*'
```