### PR TITLE
auth: Add a new extra authenticator for basic JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ settings are related to authorization:
 | `GROUPS_ALLOWLIST` | "*" | List of groups that are allowed to pass authorization. By default, all groups are allowed. If you change this option, you may want to include the `system:serviceaccounts` group explicitly, if you need the AuthService to accept ServiceAccountTokens. |
 | `EXTERNAL_AUTHZ_URL` | "" | Use an external authorization service. This option is disabled by default, to enable set the value to the target external authorization service (e.g. `EXTERNAL_AUTHZ_URL=http://authorizer/auth`). If you have enabled this option then for a request to be authorized, **both** the group and the external authorization service will have to allow the request. |
 
+## Extra JWT From Token authentication
+
+This authentication is similar to the JWT auth, except that it will use the JWT in a specific header.
+This auth is disabled by default. Options to enable it:
+
+| Setting | Default | Description |
+| - | - | - |
+| JWTFROMEXTRAPROVIDER_AUTHN_ENABLED | `false` | Set to `true` to enable this auth
+| JWTFROMEXTRAPROVIDER_PROVIDER_URL | "" | Set to the oidc provider url
+| JWTFROMEXTRAPROVIDER_ISSUER | `` | The issuer |
+| JWTFROMEXTRAPROVIDER_ISSUERNAME | `` | The issuer name |
+| JWTFROMEXTRAPROVIDER_HEADER_NAME | "" | Set to the header name where the JWT is set
+| JWTFROMEXTRAPROVIDER_CLIENTID | "" | Set to the clientID the jwt should have
+
 ## Usage
 
 OIDC-Authservice is an OIDC Client, which authenticates users with an OIDC Provider and assigns them a session.

--- a/authenticators/jwt_from_extra_provider.go
+++ b/authenticators/jwt_from_extra_provider.go
@@ -1,0 +1,107 @@
+package authenticators
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/arrikto/oidc-authservice/common"
+	goidc "github.com/coreos/go-oidc"
+	"github.com/pkg/errors"
+	"k8s.io/utils/strings/slices"
+)
+
+const bearerPrefix = "Bearer "
+
+type jwtFromExtraProviderAuthenticator struct {
+	headerName   string
+	issuer       string
+	issuerName   string
+	clientID     string
+	remoteKeySet goidc.KeySet
+}
+
+// This is not a full implementation of OIDC
+// It *just* checks the token against the keys of an extra provider.
+func NewJWTFromExtraProviderAuthenticator(
+	headerName, issuer, issuerName, clientID string,
+	providerURL *url.URL) (Authenticator, error) {
+
+	if !slices.Contains([]string{"http", "https"}, providerURL.Scheme) {
+		return nil, fmt.Errorf(
+			"Error creating jwt from extra provider authenticator: "+
+				"provider URL is incorrect: %s",
+			providerURL.String())
+	}
+	if headerName == "" {
+		return nil, errors.New(
+			"Error creating jwt from extra provider authenticator: header name is empty")
+	}
+	if clientID == "" {
+		return nil, errors.New(
+			"Error creating jwt from extra provider authenticator: clientID is empty")
+	}
+
+	return &jwtFromExtraProviderAuthenticator{
+		headerName:   headerName,
+		issuer:       issuer,
+		issuerName:   issuerName,
+		clientID:     clientID,
+		remoteKeySet: goidc.NewRemoteKeySet(context.Background(), providerURL.String()+"/keys"),
+	}, nil
+}
+
+func (s *jwtFromExtraProviderAuthenticator) Authenticate(w http.ResponseWriter, r *http.Request) (*common.User, bool, error) {
+	logger := common.RequestLogger(r, "JWT extra token authenticator")
+
+	if len(r.Header[s.headerName]) != 1 {
+		return nil, false, nil
+	}
+
+	rawIDToken := strings.TrimPrefix(r.Header[s.headerName][0], bearerPrefix)
+
+	// Validate token
+	verifier := goidc.NewVerifier(s.issuer, s.remoteKeySet, &goidc.Config{ClientID: s.clientID})
+	jwt, err := verifier.Verify(r.Context(), rawIDToken)
+	if err != nil {
+		return nil, false, &common.AuthenticatorSpecificError{Err: err}
+	}
+	// Retrieve the USERID_CLAIM and the GROUPS_CLAIM
+	var claims map[string]interface{}
+	if claimErr := jwt.Claims(&claims); claimErr != nil {
+		logger.Errorf("Retrieving user claims failed: %v", claimErr)
+		return nil, false, &common.AuthenticatorSpecificError{Err: claimErr}
+	}
+	userID, groups, claimErr := s.retrieveUserIDGroupsClaims(claims)
+	if claimErr != nil {
+		return nil, false, &common.AuthenticatorSpecificError{Err: claimErr}
+	}
+
+	user := common.User{
+		Name:   userID + ":" + s.issuerName,
+		Groups: groups,
+	}
+	return &user, true, nil
+}
+
+// Retrieve the USERID_CLAIM and the GROUPS_CLAIM from the JWT access token
+func (s *jwtFromExtraProviderAuthenticator) retrieveUserIDGroupsClaims(claims map[string]interface{}) (string, []string, error) {
+
+	if claims["email"] == nil {
+		claimErr := fmt.Errorf("USERID_CLAIM not found in the JWT token")
+		return "", []string{}, claimErr
+	}
+
+	var groups []string
+	groupsClaim := claims["groups"]
+	if groupsClaim == nil {
+		claimErr := fmt.Errorf("GROUPS_CLAIM not found in the JWT token")
+		return "", []string{}, claimErr
+	}
+
+	groups = common.InterfaceSliceToStringSlice(groupsClaim.([]interface{}))
+
+	return claims["email"].(string), groups, nil
+}

--- a/common/settings.go
+++ b/common/settings.go
@@ -77,10 +77,16 @@ type Config struct {
 	CacheExpirationMinutes int  `split_words:"true" default:"5" envconfig:"CACHE_EXPIRATION_MINUTES"`
 
 	// Authenticators configurations
-	IDTokenAuthnEnabled     bool   `split_words:"true" default:"true" envconfig:"IDTOKEN_AUTHN_ENABLED"`
-	KubernetesAuthnEnabled  bool   `split_words:"true" default:"true" envconfig:"KUBERNETES_AUTHN_ENABLED"`
-	AccessTokenAuthnEnabled bool   `split_words:"true" default:"true" envconfig:"ACCESS_TOKEN_AUTHN_ENABLED"`
-	AccessTokenAuthn        string `split_words:"true" default:"jwt" envconfig:"ACCESS_TOKEN_AUTHN"`
+	IDTokenAuthnEnabled             bool     `split_words:"true" default:"true" envconfig:"IDTOKEN_AUTHN_ENABLED"`
+	KubernetesAuthnEnabled          bool     `split_words:"true" default:"true" envconfig:"KUBERNETES_AUTHN_ENABLED"`
+	AccessTokenAuthnEnabled         bool     `split_words:"true" default:"true" envconfig:"ACCESS_TOKEN_AUTHN_ENABLED"`
+	AccessTokenAuthn                string   `split_words:"true" default:"jwt" envconfig:"ACCESS_TOKEN_AUTHN"`
+	JWTFromExtraProviderEnabled     bool     `split_words:"true" default:"false" envconfig:"JWTFROMEXTRAPROVIDER_AUTHN_ENABLED"`
+	JWTFromExtraProviderProviderURL *url.URL `default:"" envconfig:"JWTFROMEXTRAPROVIDER_PROVIDER_URL"`
+	JWTFromExtraProviderHeaderName  string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_HEADER_NAME"`
+	JWTFromExtraProviderIssuer      string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_ISSUER"`
+	JWTFromExtraProviderIssuerName  string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_ISSUERNAME"`
+	JWTFromExtraProviderClientID    string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_CLIENTID"`
 
 	// Authorization
 	GroupsAllowlist  []string `split_words:"true" default:"*"`

--- a/main.go
+++ b/main.go
@@ -188,6 +188,20 @@ func main() {
 		authorizers = append(authorizers, externalAuthorizer)
 	}
 
+	var jwtFromExtraProviderAuthenticator authenticators.Authenticator
+	// Add the jwt extra authentication
+	if c.JWTFromExtraProviderEnabled {
+		jwtFromExtraProviderAuthenticator, err = authenticators.NewJWTFromExtraProviderAuthenticator(
+			c.JWTFromExtraProviderHeaderName,
+			c.JWTFromExtraProviderIssuer,
+			c.JWTFromExtraProviderIssuerName,
+			c.JWTFromExtraProviderClientID,
+			c.JWTFromExtraProviderProviderURL)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
 	// Set the server values.
 	// The isReady atomic variable should protect it from concurrency issues.
 
@@ -217,16 +231,18 @@ func main() {
 		cacheEnabled:           c.CacheEnabled,
 		cacheExpirationMinutes: c.CacheExpirationMinutes,
 
-		IDTokenAuthnEnabled:     c.IDTokenAuthnEnabled,
-		KubernetesAuthnEnabled:  c.KubernetesAuthnEnabled,
-		AccessTokenAuthnEnabled: c.AccessTokenAuthnEnabled,
-		AccessTokenAuthn:        c.AccessTokenAuthn,
+		IDTokenAuthnEnabled:         c.IDTokenAuthnEnabled,
+		KubernetesAuthnEnabled:      c.KubernetesAuthnEnabled,
+		AccessTokenAuthnEnabled:     c.AccessTokenAuthnEnabled,
+		AccessTokenAuthn:            c.AccessTokenAuthn,
+		JWTFromExtraProviderEnabled: c.JWTFromExtraProviderEnabled,
 		authenticators: []authenticators.Authenticator{
 			k8sAuthenticator,
 			opaqueTokenAuthenticator,
 			jwtTokenAuthenticator,
 			sessionAuthenticator,
 			idTokenAuthenticator,
+			jwtFromExtraProviderAuthenticator,
 		},
 		authorizers:    authorizers,
 		tlsCfg:         tlsCfg,

--- a/server.go
+++ b/server.go
@@ -31,6 +31,7 @@ var (
 		2: "JWT access token authenticator",
 		3: "session authenticator",
 		4: "idtoken authenticator",
+		5: "jwt from extra provider authenticator",
 	}
 )
 
@@ -51,10 +52,11 @@ type server struct {
 	cacheExpirationMinutes int
 
 	// Authenticators Configurations
-	IDTokenAuthnEnabled     bool
-	KubernetesAuthnEnabled  bool
-	AccessTokenAuthnEnabled bool
-	AccessTokenAuthn        string
+	IDTokenAuthnEnabled         bool
+	KubernetesAuthnEnabled      bool
+	AccessTokenAuthnEnabled     bool
+	AccessTokenAuthn            string
+	JWTFromExtraProviderEnabled bool
 
 	authHeader        string
 	idTokenOpts       common.JWTClaimOpts
@@ -514,6 +516,9 @@ func (s *server) enabledAuthenticator(authenticator string) bool {
 		return true
 	}
 	if authenticator == "idtoken authenticator" && s.IDTokenAuthnEnabled {
+		return true
+	}
+	if authenticator == "jwt from extra provider authenticator" && s.JWTFromExtraProviderEnabled {
 		return true
 	}
 	return false


### PR DESCRIPTION
This adds a new method which can simply check a JWT against a set of keys and an issuer.
This is useful to allow a JWT generated from another dex instance.

**Which issue is resolved by this Pull Request:**
Resolves cross-cluster auth, where we run different dex instances.

**Description of your changes:**
This adds a new method which can simply check a JWT against a set of
keys and an issuer.
This is useful to allow a JWT generated from another dex instance.

**Requirements:**
- Make sure your PR conforms to our [contribution guidelines](../CONTRIBUTING.md)
