### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,12 @@ RUN addgroup -S -g 111 $GROUP && adduser -S -G $GROUP $USER
 ENV APP_HOME=/home/$USER
 WORKDIR $APP_HOME
 
-# Copy in binary and give permissions
-COPY --from=builder /go/bin/oidc-authservice $APP_HOME
-COPY web $APP_HOME/web
-RUN chmod +x $APP_HOME/oidc-authservice
 RUN chown -R $USER:$GROUP $APP_HOME
 
 USER $USER
+
+# Copy in binary
+COPY --from=builder /go/bin/oidc-authservice $APP_HOME
+COPY web $APP_HOME/web
 
 ENTRYPOINT [ "./oidc-authservice" ]


### PR DESCRIPTION
The generated docker image is around 150Mi. That's because we copy twice the binary into layers by doing this:

RUN chmod +x $APP_HOME/oidc-authservice
RUN chown -R $USER:$GROUP $APP_HOME

We can just switch to the USER before we copy, and we reduce the docker image from 160Mi to 47Mi.
