### PR TITLE
extra-auth: Modify behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Applications can then use those headers to identify the user.
 | `AUTH_METHOD_HEADER` | "Auth-Method" | Name of the header that is included in the proxied requests to inform the upstream app about the authentication method used (`cookie` / `header`). |
 | `TOKEN_HEADER` | "Authorization" | Name of the header containing user id token (JWT) that will be added to the upstream request. |
 | `TOKEN_SCHEME` | "Bearer" | Authorization scheme (e.g. Bearer, Basic) used for user id token. |
+| `SESSION_JWTCOOKIE` | "" | When not empty, this is the name of the cookie set to the JWT |
 
 OIDC AuthService can authenticate clients based on the bearer token found in the Authorization header of their request. It caches the bearer token and the respective user information. If the incoming request has a cached bearer token then AuthService authenticates this client and proceeds with the basic authorization checks. The following
 settings are related to the caching mechanism:
@@ -158,7 +159,7 @@ settings are related to authorization:
 
 ## Extra JWT From Token authentication
 
-This authentication is similar to the JWT auth, except that it will use the JWT in a specific header.
+This authentication is similar to the JWT auth, except that it will use the JWT in a specific cookie.
 This auth is disabled by default. Options to enable it:
 
 | Setting | Default | Description |
@@ -167,8 +168,9 @@ This auth is disabled by default. Options to enable it:
 | JWTFROMEXTRAPROVIDER_PROVIDER_URL | "" | Set to the oidc provider url
 | JWTFROMEXTRAPROVIDER_ISSUER | `` | The issuer |
 | JWTFROMEXTRAPROVIDER_ISSUERNAME | `` | The issuer name |
-| JWTFROMEXTRAPROVIDER_HEADER_NAME | "" | Set to the header name where the JWT is set
+| JWTFROMEXTRAPROVIDER_COOKIE_NAME | "" | Set to the cookie name where the JWT is set
 | JWTFROMEXTRAPROVIDER_CLIENTID | "" | Set to the clientID the jwt should have
+| JWTFROMEXTRAPROVIDER_SETHEADER | "" | Set the HTTP header to the JWT value. Empty to not set any header
 
 ## Usage
 

--- a/common/settings.go
+++ b/common/settings.go
@@ -43,6 +43,8 @@ type Config struct {
 	UserIDTransformer UserIDTransformer `envconfig:"USERID_TRANSFORMERS"`
 	TokenHeader       string            `split_words:"true" default:"Authorization"`
 	TokenScheme       string            `split_words:"true" default:"Bearer"`
+	// When not empty, this is the name of the cookie set to the JWT
+	JWTCookie         string            `split_words:"true" envconfig:"SESSION_JWTCOOKIE"`
 
 	// IDToken
 	UserIDClaim       string `split_words:"true" default:"email" envconfig:"USERID_CLAIM"`
@@ -83,10 +85,11 @@ type Config struct {
 	AccessTokenAuthn                string   `split_words:"true" default:"jwt" envconfig:"ACCESS_TOKEN_AUTHN"`
 	JWTFromExtraProviderEnabled     bool     `split_words:"true" default:"false" envconfig:"JWTFROMEXTRAPROVIDER_AUTHN_ENABLED"`
 	JWTFromExtraProviderProviderURL *url.URL `default:"" envconfig:"JWTFROMEXTRAPROVIDER_PROVIDER_URL"`
-	JWTFromExtraProviderHeaderName  string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_HEADER_NAME"`
+	JWTFromExtraProviderCookieName  string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_COOKIE_NAME"`
 	JWTFromExtraProviderIssuer      string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_ISSUER"`
 	JWTFromExtraProviderIssuerName  string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_ISSUERNAME"`
 	JWTFromExtraProviderClientID    string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_CLIENTID"`
+	JWTFromExtraProviderSetHeader   string   `default:"" envconfig:"JWTFROMEXTRAPROVIDER_SETHEADER"`
 
 	// Authorization
 	GroupsAllowlist  []string `split_words:"true" default:"*"`

--- a/main.go
+++ b/main.go
@@ -192,10 +192,11 @@ func main() {
 	// Add the jwt extra authentication
 	if c.JWTFromExtraProviderEnabled {
 		jwtFromExtraProviderAuthenticator, err = authenticators.NewJWTFromExtraProviderAuthenticator(
-			c.JWTFromExtraProviderHeaderName,
+			c.JWTFromExtraProviderCookieName,
 			c.JWTFromExtraProviderIssuer,
 			c.JWTFromExtraProviderIssuerName,
 			c.JWTFromExtraProviderClientID,
+			c.JWTFromExtraProviderSetHeader,
 			c.JWTFromExtraProviderProviderURL)
 		if err != nil {
 			log.Fatal(err.Error())
@@ -230,6 +231,7 @@ func main() {
 		sessionMaxAgeSeconds:   c.SessionMaxAge,
 		cacheEnabled:           c.CacheEnabled,
 		cacheExpirationMinutes: c.CacheExpirationMinutes,
+		jwtCookie:              c.JWTCookie,
 
 		IDTokenAuthnEnabled:         c.IDTokenAuthnEnabled,
 		KubernetesAuthnEnabled:      c.KubernetesAuthnEnabled,

--- a/server.go
+++ b/server.go
@@ -46,6 +46,7 @@ type server struct {
 	afterLogoutRedirectURL string
 	verifyAuthURL          string
 	sessionMaxAgeSeconds   int
+	jwtCookie              string
 
 	// Cache Configurations
 	cacheEnabled           bool
@@ -496,6 +497,20 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.WithField("redirectTo", destination).
 		Info("Login validated with ID token, redirecting.")
+
+	// Add JWT cookie if needed
+	if s.jwtCookie != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     s.jwtCookie,
+			Value:    rawIDToken,
+			Path:     "/",
+			Domain:   session.Options.Domain,
+			MaxAge:   s.sessionMaxAgeSeconds,
+			SameSite: session.Options.SameSite,
+			Secure:   true,
+			HttpOnly: true,
+		})
+	}
 	http.Redirect(w, r, destination, http.StatusFound)
 }
 


### PR DESCRIPTION
Grafana cannot pass headers, so the extra auth cannot really use http headers to get the JWT.
So, we change the behavior to use a cookie to transport the JWT. The cookie is set as session creation (when enabled). Then, we tell grafana to pass this cookie to the datasource and the oidc-auth on the target cluster can use this cookie to read the JWT.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Requirements:**
- Make sure your PR conforms to our [contribution guidelines](../CONTRIBUTING.md)
