### PR TITLE
fix: Fix time conversion bug when setting session.Options.MaxAge

### DIFF
--- a/sessions/state.go
+++ b/sessions/state.go
@@ -87,7 +87,7 @@ func CreateState(r *http.Request, w http.ResponseWriter,
 	store sessions.Store, sessionDomain string, fn StateFunc) (string, error) {
 	s := fn(r)
 	session := sessions.NewSession(store, oidcStateCookie)
-	session.Options.MaxAge = int(20 * time.Minute)
+	session.Options.MaxAge = int((20 * time.Minute).Seconds())
 	session.Options.Path = "/"
 	session.Options.Domain = sessionDomain
 	session.Values[sessionValueState] = *s


### PR DESCRIPTION
In sessions.state.CreateState(), the maxAge for the session was being set using:

`session.Options.MaxAge = int(20 * time.Minute)`

This is problematic because MaxAge is an int that represents seconds [1] ; int(20 * time.Minute) gets translated to 1,200,000,000,000 seconds.

Illustration:

	//=== BUGGY CODE
	maxAge := int(20 * time.Minute)

	// 1,200,000,000,000. This is an integer representing nanoseconds.
	fmt.Println(maxAge)

	redisExpirationDuration := time.Duration(maxAge) * time.Second

	// 267120h 53m 28.87914496s
	// This gets converted to 961,635,208,879 ms by redis client code,
	// which is approximately 961 million seconds or 30 years
	fmt.Println(redisExpirationDuration)

	//=== FIXED CODE
	maxAge = int((20 * time.Minute).Seconds())

	// 1200 (matches expectation)
	fmt.Println(maxAge)

	redisExpirationDuration = time.Duration(maxAge) * time.Second

	// 20m 0s (matches expectation)
	fmt.Println(redisExpirationDuration)

Other notes:
- MaxAge is to do with the Max-Age attribute in session cookies; however the underlying redisstore code uses MaxAge to set the TTL on the Redis keys as well
- See logs from redis (DEV) showing how the `redisstore` client was setting an expiry via `PX 961635208879`.

[1] https://pkg.go.dev/github.com/gorilla/sessions@v1.2.1#Options
[2] https://pb.infra.corp.arista.io/q21C9RnB