### PR TITLE
authenticators/extra: remove issuer from email

### DIFF
--- a/authenticators/jwt_from_extra_provider.go
+++ b/authenticators/jwt_from_extra_provider.go
@@ -78,7 +78,7 @@ func (s *jwtFromExtraProviderAuthenticator) Authenticate(w http.ResponseWriter, 
 	}
 
 	user := common.User{
-		Name:   userID + ":" + s.issuerName,
+		Name:   userID,
 		Groups: groups,
 	}
 	if s.setHeader != "" {


### PR DESCRIPTION
**Description of your changes:**

This removes the `:issuer` thing added to the email by this authenticator.
I think this was added _just in case_, but it actually breaks things, because some code relies on the headers. 