### PR TITLE
feat(authenticators/idtoken): Verify without ClientID

### DIFF
--- a/authenticators/idtoken.go
+++ b/authenticators/idtoken.go
@@ -34,8 +34,6 @@ func (s *IDTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Reque
 	logger := common.RequestLogger(r, "idtoken authenticator")
 	logger.Infof("Attempting idtoken authentication using token header '%s'", s.Header)
 
-	clientID := r.Header.Get("X-OIDC-Client-Id")
-
 	// get id-token from header
 	bearer := common.GetBearerToken(r.Header.Get(s.Header))
 	if len(bearer) == 0 {
@@ -46,7 +44,7 @@ func (s *IDTokenAuthenticator) Authenticate(w http.ResponseWriter, r *http.Reque
 	ctx := s.TLSConfig.Context(r.Context())
 
 	// Verifying received ID token
-	token, err := s.SessionManager.Verify(ctx, bearer, clientID)
+	token, err := s.SessionManager.VerifyWithoutClientId(ctx, bearer)
 	if err != nil {
 		logger.Errorf("id-token verification failed: %v", err)
 		return nil, false, nil

--- a/sessions/manager.go
+++ b/sessions/manager.go
@@ -100,6 +100,12 @@ func (s *SessionManager) VerifyWithClientId(ctx context.Context,
 	return verifier.Verify(ctx, idToken)
 }
 
+func (s *SessionManager) VerifyWithoutClientId(ctx context.Context,
+	idToken string) (*goidc.IDToken, error) {
+	verifier := s.provider.Verifier(&goidc.Config{SkipClientIDCheck: true})
+	return verifier.Verify(ctx, idToken)
+}
+
 // TokenSource is a wrapper around oauth2.Config.TokenSource that additionally
 // returns a boolean indicator for a token refresh.
 func (s *SessionManager) TokenSource(ctx context.Context,


### PR DESCRIPTION
Remove the need to define the clientID via the X-OIDC-Client-Id by skipping the ClientID check all together
