### PR TITLE
feat(authenticators/idtoken): emit the same header to upstream service as session.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,8 @@ func main() {
 		c.GroupsClaim,
 		tlsCfg,
 		sessionManager,
+		c.TokenHeader,
+		c.TokenScheme,
 	)
 
 	jwtTokenAuthenticator := authenticators.NewJWTTokenAuthenticator(


### PR DESCRIPTION
The session authenticator will emit the user's token on the header defined by "TokenHeader".

This PR patches the idtoken authenticator to match this behaviour