### PR TITLE
fix: correctly delete cookie when revoking session

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func main() {
 		c.StrictSessionValidation,
 		tlsCfg,
 		sessionManager,
+		s.sessionDomain,
 	)
 
 	idTokenAuthenticator := authenticators.NewIDTokenAuthenticator(

--- a/server.go
+++ b/server.go
@@ -311,7 +311,7 @@ func (s *server) authorized(w http.ResponseWriter, r *http.Request, userInfo *co
 				logger.Errorf("Error getting session for request: %v", err)
 			}
 			if !session.IsNew {
-				err := s.sessionManager.RevokeSession(r.Context(), w, session, s.tlsCfg)
+				err := s.sessionManager.RevokeSession(r.Context(), w, session, s.tlsCfg, s.sessionDomain)
 				if err != nil {
 					logger.Errorf("Failed to revoke session after authorization fail: %v", err)
 				}
@@ -405,7 +405,7 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If state is loaded, then it's correct, as it is saved by its id.
-	state, err := sessions.VerifyState(r, w, s.oidcStateStore, s.dynamicCsrfCookieName)
+	state, err := sessions.VerifyState(r, w, s.oidcStateStore, s.dynamicCsrfCookieName, s.sessionDomain)
 	if err != nil {
 		logger.Errorf("Failed to verify state parameter: %v", err)
 		common.ReturnMessage(w, http.StatusBadRequest, "CSRF check failed."+
@@ -565,7 +565,7 @@ func (s *server) logout(w http.ResponseWriter, r *http.Request) {
 	}
 	logger = logger.WithField("userid", session.Values[sessions.UserSessionUserID].(string))
 
-	err = s.sessionManager.RevokeSession(r.Context(), w, session, s.tlsCfg)
+	err = s.sessionManager.RevokeSession(r.Context(), w, session, s.tlsCfg, s.sessionDomain)
 	if err != nil {
 		logger.Errorf("Error revoking tokens: %v", err)
 		statusCode := http.StatusInternalServerError

--- a/sessions/manager.go
+++ b/sessions/manager.go
@@ -82,8 +82,9 @@ func (s *SessionManager) ExchangeCode(
 }
 
 func (s *SessionManager) RevokeSession(
-	ctx context.Context, w http.ResponseWriter, session *sessions.Session, tlsCfg common.TlsConfig) error {
-	return s.RevokeOIDCSession(ctx, w, session, tlsCfg)
+	ctx context.Context, w http.ResponseWriter, session *sessions.Session, tlsCfg common.TlsConfig,
+	sessionDomain string) error {
+	return s.RevokeOIDCSession(ctx, w, session, tlsCfg, sessionDomain)
 }
 
 func (s *SessionManager) Verify(ctx context.Context, idToken, clientID string) (*goidc.IDToken, error) {
@@ -154,7 +155,7 @@ func (s *SessionManager) SaveToken(session *sessions.Session, ctx context.Contex
 // TODO: In the future, we may want to make this function take a function as
 // input, instead of polluting it with extra arguments.
 func (s *SessionManager) RevokeOIDCSession(ctx context.Context, w http.ResponseWriter,
-	session *sessions.Session, tlsCfg common.TlsConfig) error {
+	session *sessions.Session, tlsCfg common.TlsConfig, sessionDomain string) error {
 
 	logger := common.StandardLogger()
 
@@ -172,5 +173,5 @@ func (s *SessionManager) RevokeOIDCSession(ctx context.Context, w http.ResponseW
 		logger.WithField("userid", session.Values[UserSessionUserID].(string)).Info("Access/Refresh tokens revoked")
 	}
 
-	return revokeSession(ctx, w, session)
+	return revokeSession(ctx, w, session, sessionDomain)
 }

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -121,7 +121,7 @@ func SessionFromRequest(r *http.Request, store sessions.Store, cookie,
 
 // revokeSession revokes the given session.
 func revokeSession(ctx context.Context, w http.ResponseWriter,
-	session *sessions.Session) error {
+	session *sessions.Session, sessionDomain string) error {
 
 	// Delete the session by setting its MaxAge to a negative number.
 	// This will delete the session from the store and also add a "Set-Cookie"
@@ -129,6 +129,7 @@ func revokeSession(ctx context.Context, w http.ResponseWriter,
 	// XXX: The session.Save function doesn't really need the request, but only
 	// uses it for its context.
 	session.Options.MaxAge = -1
+	session.Options.Domain = sessionDomain
 	r := &http.Request{}
 	if err := session.Save(r.WithContext(ctx), w); err != nil {
 		return errors.Wrap(err, "Couldn't delete user session")

--- a/sessions/state.go
+++ b/sessions/state.go
@@ -88,10 +88,10 @@ func newSchemeAndHost(config *Config) StateFunc {
 func stringWithCharset(length int, charset string) string {
 	b := make([]byte, length)
 	for i := range b {
-	  b[i] = charset[seededRand.Intn(len(charset))]
+		b[i] = charset[seededRand.Intn(len(charset))]
 	}
 	return string(b)
-  }
+}
 
 // randString returns a random string of given length
 func randString(length int) string {
@@ -106,7 +106,7 @@ func CreateState(r *http.Request, w http.ResponseWriter, store sessions.Store,
 	sessionDomain string, fn StateFunc, dynamicOidcStateCookieName bool) (string, error) {
 	nonce := randString(8)
 	oidcStateCookieName := oidcStateCookie
-	if (dynamicOidcStateCookieName) {
+	if dynamicOidcStateCookieName {
 		oidcStateCookieName += "_" + nonce
 	}
 	s := fn(r)
@@ -129,7 +129,7 @@ func CreateState(r *http.Request, w http.ResponseWriter, store sessions.Store,
 		return "", errors.Wrap(err, "error trying to save session")
 	}
 	stateValue := c.Value
-	if (dynamicOidcStateCookieName) {
+	if dynamicOidcStateCookieName {
 		stateValue += "." + nonce
 	}
 	return stateValue, nil
@@ -145,7 +145,8 @@ func CreateState(r *http.Request, w http.ResponseWriter, store sessions.Store,
 // Finally, it returns a State struct, which contains information associated
 // with the particular OIDC flow.
 func VerifyState(r *http.Request, w http.ResponseWriter,
-	store sessions.Store, dynamicOidcStateCookieName bool) (*State, error) {
+	store sessions.Store, dynamicOidcStateCookieName bool,
+	sessionDomain string) (*State, error) {
 
 	// Get the state from the HTTP param.
 	var stateParam = r.FormValue("state")
@@ -156,7 +157,7 @@ func VerifyState(r *http.Request, w http.ResponseWriter,
 	oidcStateCookieName := oidcStateCookie
 	stateValue := stateParam
 	nonce := ""
-	if (dynamicOidcStateCookieName) {
+	if dynamicOidcStateCookieName {
 		stateParamParts := strings.Split(stateParam, ".")
 		stateValue = stateParamParts[0]
 		nonce = stateParamParts[1]
@@ -189,7 +190,7 @@ func VerifyState(r *http.Request, w http.ResponseWriter,
 	state := session.Values[sessionValueState].(State)
 
 	// Revoke the session so that each state value can only be used once.
-	if err = revokeSession(r.Context(), w, session); err != nil {
+	if err = revokeSession(r.Context(), w, session, sessionDomain); err != nil {
 		return nil, errors.Wrap(err, "error revoking state session")
 	}
 	return &state, nil


### PR DESCRIPTION
rfc6265 states: "to remove a cookie, the server returns a Set-Cookie header with an expiration date in the past.  The server will be successful in removing the cookie only if the Path and the Domain attribute in the Set-Cookie header match the values used when the cookie was created."

Before this PR, the domain is defined when the cookie is set, but is not defined when the cookie is deleted. This PR addresses this, and results in the cookie actually being deleted
