### PR TITLE
feat: Do not redirect robot-users to the login portal

### DIFF
--- a/server.go
+++ b/server.go
@@ -202,15 +202,25 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 			return nil, false
 		}
 
-		logger.Infof("Failed to authenticate using authenticators. Initiating OIDC Authorization Code flow...")
-		if requestedWith := r.Header.Get("X-Requested-With"); len(requestedWith) > 0 {
-			// Nonempty X-Requested-With header implies that this is an m2m request and
+		switch r.Header.Get("X-On-Unauthorized") {
+		case "", "redirect":
+			// Our default behavior here is to redirect the user to a login portal. This
+			// is very convenient for when the client is a web-browser.
+			logger.Infof("Failed to authenticate using authenticators. Initiating OIDC Authorization Code flow...")
+			s.authCodeFlowAuthenticationRequest(w, r)
+			return nil, false
+		case "reject":
+			// The client has requested a 4xx response (they are probably a robot client)
 			// so we should not try to redirect the caller to a human-centric login portal.
+			logger.Infof("Failed to authenticate using authenticators. Rejecting based on request headers")
 			common.ReturnMessage(w, http.StatusUnauthorized, "Unauthorized")
 			return nil, false
+		default:
+			common.ReturnMessage(w,
+				http.StatusBadRequest,
+				"Unrecognized value for X-On-Unauthorized header")
+			return nil, false
 		}
-		s.authCodeFlowAuthenticationRequest(w, r)
-		return nil, false
 	}
 
 	logger = logger.WithField("user", userInfo)

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"reflect"
 	"strings"
@@ -21,6 +22,10 @@ import (
 
 const (
 	logModuleInfo = "server"
+
+	xOnUnauthorizedHeader             = "X-On-Unauthorized"
+	xOnUnauthorizedRedirect           = "redirect"
+	xOnUnauthorizedStatusUnauthorized = "return-status-unauthorized"
 )
 
 var (
@@ -202,14 +207,19 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 			return nil, false
 		}
 
-		switch r.Header.Get("X-On-Unauthorized") {
-		case "", "redirect":
+		onUnauthorized := r.Header.Get(xOnUnauthorizedHeader)
+		if onUnauthorized == "" {
+			// Treat "redirect" as our default when the user did not provide a value.
+			onUnauthorized = xOnUnauthorizedRedirect
+		}
+		switch onUnauthorized {
+		case xOnUnauthorizedRedirect:
 			// Our default behavior here is to redirect the user to a login portal. This
 			// is very convenient for when the client is a web-browser.
 			logger.Infof("Failed to authenticate using authenticators. Initiating OIDC Authorization Code flow...")
 			s.authCodeFlowAuthenticationRequest(w, r)
 			return nil, false
-		case "reject":
+		case xOnUnauthorizedStatusUnauthorized:
 			// The client has requested a 4xx response (they are probably a robot client)
 			// so we should not try to redirect the caller to a human-centric login portal.
 			logger.Infof("Failed to authenticate using authenticators. Rejecting based on request headers")
@@ -218,7 +228,9 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 		default:
 			common.ReturnMessage(w,
 				http.StatusBadRequest,
-				"Unrecognized value for X-On-Unauthorized header")
+				fmt.Sprintf("Unrecognized value for header %q: %q (html-escaped)",
+					xOnUnauthorizedHeader,
+					sanitizeForBody(onUnauthorized)))
 			return nil, false
 		}
 	}
@@ -233,6 +245,14 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 	}
 
 	return userInfo, true
+}
+
+func sanitizeForBody(inpt string) string {
+	asRunes := []rune(inpt)
+	if len(asRunes) > 16 {
+		inpt = string(asRunes[:16]) + "..."
+	}
+	return html.EscapeString(inpt)
 }
 
 // tryAuthenticators will iterate over the available enabled authenticators.

--- a/server.go
+++ b/server.go
@@ -207,6 +207,7 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 			// Nonempty X-Requested-With header implies that this is an m2m request and
 			// so we should not try to redirect the caller to a human-centric login portal.
 			common.ReturnMessage(w, http.StatusUnauthorized, "Unauthorized")
+			return nil, false
 		}
 		s.authCodeFlowAuthenticationRequest(w, r)
 		return nil, false

--- a/server.go
+++ b/server.go
@@ -203,7 +203,11 @@ func (s *server) authenticate(w http.ResponseWriter, r *http.Request, promptLogi
 		}
 
 		logger.Infof("Failed to authenticate using authenticators. Initiating OIDC Authorization Code flow...")
-		// TODO: Detect "X-Requested-With" header and return 401
+		if requestedWith := r.Header.Get("X-Requested-With"); len(requestedWith) > 0 {
+			// Nonempty X-Requested-With header implies that this is an m2m request and
+			// so we should not try to redirect the caller to a human-centric login portal.
+			common.ReturnMessage(w, http.StatusUnauthorized, "Unauthorized")
+		}
 		s.authCodeFlowAuthenticationRequest(w, r)
 		return nil, false
 	}


### PR DESCRIPTION
Today when you make a request using expired tokens, oidc will redirect you to a login portal. This is nice for humans who can see the portal and decide to re-auth, but this makes things hard for robot clients. The difficulty for robot clients takes two forms: first, they are unable to use the login portal that we redirect them two; second, many programs will interpret a 302 response to mean that authentication was successful.

With this change, robot clients can opt-in to the traditional 401 behavior. We have chosen to use the "X-On-Unauthorized" header to gate this behavior because it is unlikely to be used by existing clients. We preserve the existing redirect behavior when the client does not pass in an `X-On-Unauthorized` header at all. Clients can explicitly opt-in to the redirect by passing "redirect" as the value, or can opt-in to the 401 by passing "return-status-unauthorized" as the value.

**Which issue is resolved by this Pull Request:**
Relates to https://bb.infra.corp.arista.io/bug/784367